### PR TITLE
Issue #2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,5 +31,8 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^6.5 || ^7.0"
+  },
+  "suggest": {
+    "ext-openssl": "This should be loaded if connecting server via FTPS."
   }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -262,7 +262,11 @@ class Client
         }
 
         $old = error_reporting(0);
-        if (!$this->connection = ftp_connect($this->host, $this->port)) {
+        $isSsl = substr($this->host, 0, 4) === 'ftps';
+
+        $this->connection = $isSsl ? ftp_ssl_connect($this->host, $this->port) : ftp_connect($this->host, $this->port);
+
+        if (!$this->connection) {
             error_reporting($old);
             throw new RuntimeException(sprintf('unable to connect to ftp server %s', $this->host));
         }

--- a/src/Client.php
+++ b/src/Client.php
@@ -75,12 +75,20 @@ class Client
     private $passive;
 
     /**
+     * Use ftps connection
+     *
+     * @var bool
+     */
+    private $isSecure;
+
+    /**
      * Client constructor.
      *
      * @param string $url
      * @param bool   $passive
+     * @param bool   $isSecure
      */
-    public function __construct(string $url, bool $passive = false)
+    public function __construct(string $url, bool $passive = false, bool $isSecure = false)
     {
         if (!extension_loaded('ftp')) {
             throw new RuntimeException('FTP extension is not loaded.');
@@ -262,9 +270,8 @@ class Client
         }
 
         $old = error_reporting(0);
-        $isSsl = substr($this->host, 0, 4) === 'ftps';
 
-        $this->connection = $isSsl ? ftp_ssl_connect($this->host, $this->port) : ftp_connect($this->host, $this->port);
+        $this->connection = ($this->isSecure ? ftp_ssl_connect($this->host, $this->port) : ftp_connect($this->host, $this->port));
 
         if (!$this->connection) {
             error_reporting($old);

--- a/tests/Ftp/ClientTest.php
+++ b/tests/Ftp/ClientTest.php
@@ -23,7 +23,30 @@ class ClientTest extends TestCase
      */
     public function testList()
     {
-        $client = new Client('ftp://foo:bar@example.com');
+        $client = new Client('ftp://foo:bar@example.com', false);
+        $list   = $client->ls();
+
+        $this->assertTrue($list[0]->isFile());
+        $this->assertEquals('foo.txt', $list[0]->getFilename());
+        $this->assertEquals(100, $list[0]->getSize());
+
+        $this->assertTrue($list[1]->isFile());
+        $this->assertEquals('bar.txt', $list[1]->getFilename());
+
+        $this->assertFalse($list[2]->isFile());
+        $this->assertEquals('fiz', $list[2]->getFilename());
+
+        if (version_compare(PHP_VERSION, '7.2.0', '>=')) {
+            call_user_func_array('ftp_mlsd', null, true);
+        } else {
+            call_user_func_array('ftp_nlist', null, true);
+            call_user_func_array('ftp_mdtm', null, true);
+            call_user_func_array('ftp_pwd', null, true);
+            call_user_func_array('ftp_chdir', null, true);
+            call_user_func_array('ftp_size', null, true);
+        }
+
+        $client = new Client('ftps://foo:bar@example.com', true);
         $list   = $client->ls();
 
         $this->assertTrue($list[0]->isFile());

--- a/tests/Ftp/FileTest.php
+++ b/tests/Ftp/FileTest.php
@@ -46,7 +46,7 @@ class FileTest extends TestCase
         $file = new File(['type' => 'file', 'name' => 'foo.txt', 'size' => 100]);
         $date = $file->getLastModifyDate();
 
-        $this->assertTrue(is_a($date, \DateTimeImmutable::class));
+        $this->assertInstanceOf(\DateTimeImmutable::class, $date);
     }
 
     /**
@@ -59,7 +59,7 @@ class FileTest extends TestCase
     }
 
     /**
-     * Tests File::isDir
+     * Tests File::isFile
      */
     public function testIsDir()
     {

--- a/tests/mock.functions.php
+++ b/tests/mock.functions.php
@@ -67,9 +67,23 @@ function ftp_login($connection, $user, $password)
  * @param  array  $args
  * @return bool
  */
-function call_user_func_array($name, $args)
+function call_user_func_array($name = '', $args = '', $isTwice = false)
 {
     static $iterations;
+
+    if ($isTwice) {
+        if ($name === 'ftp_mdtm') {
+            $iterations[$name] = 0;
+        }
+        if ($name === 'ftp_mlsd') {
+            $iterations[$name]--;
+        }
+        if ($name === 'ftp_nlist' || $name === 'ftp_chdir' || $name === 'ftp_pwd' || $name === 'ftp_size') {
+            $iterations[$name] = 0;
+        }
+
+        return true;
+    }
 
     $iteration = $iterations[$name] ?? 0;
     $iterations[$name]++;

--- a/tests/mock.functions.php
+++ b/tests/mock.functions.php
@@ -21,6 +21,19 @@ function ftp_connect($host, $port)
     return ['host' => $host, 'port' => $port];
 }
 
+
+/**
+ * Mock internal ftp_ssl_connect.
+ *
+ * @param  string $host
+ * @param  string $port
+ * @return array
+ */
+function ftp_ssl_connect($host, $port)
+{
+    return ['host' => $host, 'port' => $port];
+}
+
 /**
  * Mock internal ftp_login.
  *

--- a/tests/mock.functions.php
+++ b/tests/mock.functions.php
@@ -72,13 +72,7 @@ function call_user_func_array($name = '', $args = '', $isTwice = false)
     static $iterations;
 
     if ($isTwice) {
-        if ($name === 'ftp_mdtm') {
-            $iterations[$name] = 0;
-        }
-        if ($name === 'ftp_mlsd') {
-            $iterations[$name]--;
-        }
-        if ($name === 'ftp_nlist' || $name === 'ftp_chdir' || $name === 'ftp_pwd' || $name === 'ftp_size') {
+        if ($name === 'ftp_mlsd' || $name === 'ftp_mdtm' || $name === 'ftp_nlist' || $name === 'ftp_chdir' || $name === 'ftp_pwd' || $name === 'ftp_size') {
             $iterations[$name] = 0;
         }
 


### PR DESCRIPTION
# Changed log
- To add `FTPS` support, add the optional `$isSecure` parameter inside `Client` class constructor.
- To let `ClientTest::testList` method can test twice at same time, Set the `$iterations` value manually when calling some `ftp_*` functions from mocked `call_user_func_array` inside `mock.functions.php`.